### PR TITLE
[kotlin] Fix new bin/kotlin-client-nullable.sh script

### DIFF
--- a/bin/kotlin-client-nullable.sh
+++ b/bin/kotlin-client-nullable.sh
@@ -27,6 +27,6 @@ fi
 
 # if you've executed sbt assembly previously it will use that instead.
 export JAVA_OPTS="${JAVA_OPTS} -Xmx1024M -DloggerPath=conf/log4j.properties"
-ags="generate -t modules/openapi-generator/src/main/resources/kotlin-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g kotlin --artifact-id "kotlin-petstore-nullable" --additional-properties nullableReturnType=true,serializableModel=true -o samples\client\petstore\kotlin-nullable $@"
+ags="generate -t modules/openapi-generator/src/main/resources/kotlin-client -i modules/openapi-generator/src/test/resources/2_0/petstore.yaml -g kotlin --artifact-id kotlin-petstore-nullable --additional-properties nullableReturnType=true,serializableModel=true -o samples/client/petstore/kotlin-nullable $@"
 
 java ${JAVA_OPTS} -jar ${executable} ${ags}


### PR DESCRIPTION
* Sets executable flag on `bin/kotlin-client-nullable.sh`
* Removes improper quoting around artifact-id
* Uses posix path separator for output directory
